### PR TITLE
chore: added eslint-plugin-expect-type

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,6 +19,7 @@ module.exports = {
 			],
 			files: ["**/*.{ts,tsx}"],
 			rules: {
+				"expect-type/expect": "error",
 				// I only disabled these so that we wouldn't see later rules
 				// show up in earlier files... Don't copy these disables! 😉
 				"@typescript-eslint/await-thenable": "off",
@@ -52,6 +53,7 @@ module.exports = {
 		"local-rules",
 		"simple-import-sort",
 		"typescript-sort-keys",
+		"eslint-plugin-expect-type",
 	],
 	root: true,
 	rules: {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"prettier": "^2.7.1",
 		"semantic-release": "^19.0.5",
 		"ts-prune": "^0.10.3",
-		"typescript": "^4.8.4",
+		"typescript": "4.7.4",
 		"typestat": "^0.6.2",
 		"vitest": "^0.23.4"
 	},

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"cspell": "^6.12.0",
 		"eslint": "^8.24.0",
 		"eslint-config-prettier": "^8.5.0",
+		"eslint-plugin-expect-type": "^0.2.0",
 		"eslint-plugin-jsonc": "^2.4.0",
 		"eslint-plugin-local-rules": "^1.3.2",
 		"eslint-plugin-simple-import-sort": "^8.0.0",

--- a/src/linting/types.test.ts
+++ b/src/linting/types.test.ts
@@ -1,0 +1,4 @@
+import { createState } from "./types";
+
+createState();
+// ^?

--- a/src/linting/types.test.ts
+++ b/src/linting/types.test.ts
@@ -3,6 +3,6 @@ import { createState } from "./types";
 createState();
 // ^? (alias) createState(): {
 //        getValue: () => number;
-//        increment: () => void;
+//        incrementValue: () => void;
 //    }
 //    import createState

--- a/src/linting/types.test.ts
+++ b/src/linting/types.test.ts
@@ -1,8 +1,0 @@
-import { createState } from "./types";
-
-createState();
-// ^? (alias) createState(): {
-//        getValue: () => number;
-//        incrementValue: () => void;
-//    }
-//    import createState

--- a/src/linting/types.test.ts
+++ b/src/linting/types.test.ts
@@ -1,4 +1,8 @@
 import { createState } from "./types";
 
 createState();
-// ^?
+// ^? (alias) createState(): {
+//        getValue: () => number;
+//        increment: () => void;
+//    }
+//    import createState

--- a/src/linting/types.ts
+++ b/src/linting/types.ts
@@ -3,7 +3,7 @@ export function createState() {
 
 	return {
 		getValue: () => value,
-		increment: () => {
+		incrementValue: () => {
 			value += 1;
 		},
 	};

--- a/src/linting/types.ts
+++ b/src/linting/types.ts
@@ -1,0 +1,10 @@
+export function createState() {
+	let value = 1;
+
+	return {
+		getValue: () => value,
+		increment: () => {
+			value += 1;
+		},
+	};
+}

--- a/src/linting/types.ts
+++ b/src/linting/types.ts
@@ -8,3 +8,5 @@ export function createState() {
 		},
 	};
 }
+
+createState();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,5 @@
 		"strict": true,
 		"target": "ES2021"
 	},
-	"exclude": ["node_modules"],
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+	"exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5296,7 +5296,12 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.2.4, typescript@^4.8.4:
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@^4.2.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -912,6 +912,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/semver@^7.3.12":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
 "@typescript-eslint/eslint-plugin@^5.38.1":
   version "5.38.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.38.1.tgz#9f05d42fa8fb9f62304cc2f5c2805e03c01c2620"
@@ -959,6 +964,14 @@
     "@typescript-eslint/types" "5.39.0"
     "@typescript-eslint/visitor-keys" "5.39.0"
 
+"@typescript-eslint/scope-manager@5.42.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz#e1f2bb26d3b2a508421ee2e3ceea5396b192f5ef"
+  integrity sha512-l5/3IBHLH0Bv04y+H+zlcLiEMEMjWGaCX6WyHE5Uk2YkSGAMlgdUPsT/ywTSKgu9D1dmmKMYgYZijObfA39Wow==
+  dependencies:
+    "@typescript-eslint/types" "5.42.0"
+    "@typescript-eslint/visitor-keys" "5.42.0"
+
 "@typescript-eslint/type-utils@5.38.1":
   version "5.38.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.38.1.tgz#7f038fcfcc4ade4ea76c7c69b2aa25e6b261f4c1"
@@ -978,6 +991,11 @@
   version "5.39.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.39.0.tgz#f4e9f207ebb4579fd854b25c0bf64433bb5ed78d"
   integrity sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==
+
+"@typescript-eslint/types@5.42.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.42.0.tgz#5aeff9b5eced48f27d5b8139339bf1ef805bad7a"
+  integrity sha512-t4lzO9ZOAUcHY6bXQYRuu+3SSYdD9TS8ooApZft4WARt4/f2Cj/YpvbTe8A4GuhT4bNW72goDMOy7SW71mZwGw==
 
 "@typescript-eslint/typescript-estree@5.38.1":
   version "5.38.1"
@@ -999,6 +1017,19 @@
   dependencies:
     "@typescript-eslint/types" "5.39.0"
     "@typescript-eslint/visitor-keys" "5.39.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.42.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.0.tgz#2592d24bb5f89bf54a63384ff3494870f95b3fd8"
+  integrity sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==
+  dependencies:
+    "@typescript-eslint/types" "5.42.0"
+    "@typescript-eslint/visitor-keys" "5.42.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -1029,6 +1060,20 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/utils@^5.0.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.42.0.tgz#f06bd43b9a9a06ed8f29600273240e84a53f2f15"
+  integrity sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.42.0"
+    "@typescript-eslint/types" "5.42.0"
+    "@typescript-eslint/typescript-estree" "5.42.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
+
 "@typescript-eslint/visitor-keys@5.38.1":
   version "5.38.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.1.tgz#508071bfc6b96d194c0afe6a65ad47029059edbc"
@@ -1043,6 +1088,14 @@
   integrity sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==
   dependencies:
     "@typescript-eslint/types" "5.39.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.42.0":
+  version "5.42.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.0.tgz#ee8d62d486f41cfe646632fab790fbf0c1db5bb0"
+  integrity sha512-QHbu5Hf/2lOEOwy+IUw0GoSCuAzByTAWWrOTKzTzsotiUnWFpuKnXcAhC9YztAf2EElQ0VvIK+pHJUPkM0q7jg==
+  dependencies:
+    "@typescript-eslint/types" "5.42.0"
     eslint-visitor-keys "^3.3.0"
 
 JSONStream@^1.0.4:
@@ -2119,6 +2172,14 @@ eslint-config-prettier@^8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
+eslint-plugin-expect-type@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-expect-type/-/eslint-plugin-expect-type-0.2.0.tgz#1378fe03cbc4ce2e23f816919e0847ce14b66262"
+  integrity sha512-7EFziIsXfrA/Ga3RLHD1K7Yeyp5YKM7NyEpHwT+0vUkIcqz9jkOsqpH+KwiVS5/4zsGJO0gYX7koMxg11iylKA==
+  dependencies:
+    "@typescript-eslint/utils" "^5.0.0"
+    fs-extra "^10.0.1"
+
 eslint-plugin-jsonc@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.4.0.tgz#83a0f9a22689492d58514ab0464fa0612dceabc7"
@@ -2425,7 +2486,7 @@ fromentries@^1.3.2:
   resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
   integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
 
-fs-extra@^10.0.0, fs-extra@^10.1.0:
+fs-extra@^10.0.0, fs-extra@^10.0.1, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==


### PR DESCRIPTION
Sending as a reference, because this happens when you `yarn lint`:

```plaintext
Oops! Something went wrong! :(

ESLint: 8.24.0

TypeError: Error while loading rule 'expect-type/expect': host.fileExists is not a function
Occurred while linting /Users/josh/repos/typescript-static-analysis-hidden-gems/src/linting/types.test.ts
    at Object.fileExists (/Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:167620:63)
    at host.fileExists (/Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:117500:47)
    at getPackageJsonInfo (/Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:44461:37)
    at loadModuleFromSpecificNodeModulesDirectory (/Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:45001:27)
    at loadModuleFromImmediateNodeModulesDirectory (/Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:44982:58)
    at /Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:44972:39
    at Object.forEachAncestorDirectory (/Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:8370:26)
    at loadModuleFromNearestNodeModulesDirectoryWorker (/Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:44966:19)
    at loadModuleFromNearestNodeModulesDirectory (/Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:44958:16)
    at tryResolve (/Users/josh/repos/typescript-static-analysis-hidden-gems/node_modules/typescript/lib/typescript.js:44053:34)
```